### PR TITLE
feat: add Metabase piece

### DIFF
--- a/packages/pieces/community/metabase/.eslintrc.json
+++ b/packages/pieces/community/metabase/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {},
+        "extends": [
+        "plugin:prettier/recommended"
+        ],
+      "plugins": ["prettier"]
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/metabase/README.md
+++ b/packages/pieces/community/metabase/README.md
@@ -1,0 +1,7 @@
+# pieces-metabase
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-metabase` to build the library.

--- a/packages/pieces/community/metabase/package-lock.json
+++ b/packages/pieces/community/metabase/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "@activepieces/piece-metabase",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@activepieces/piece-metabase",
+      "version": "0.0.1"
+    }
+  }
+}

--- a/packages/pieces/community/metabase/package.json
+++ b/packages/pieces/community/metabase/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-metabase",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/metabase/project.json
+++ b/packages/pieces/community/metabase/project.json
@@ -1,0 +1,43 @@
+{
+  "name": "pieces-metabase",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/metabase/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/metabase",
+        "tsConfig": "packages/pieces/community/metabase/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/metabase/package.json",
+        "main": "packages/pieces/community/metabase/src/index.ts",
+        "assets": [
+          "packages/pieces/community/metabase/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "publish": {
+      "command": "node tools/scripts/publish.mjs pieces-metabase {args.ver} {args.tag}",
+      "dependsOn": [
+        "build"
+      ]
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ],
+      "options": {
+        "lintFilePatterns": [
+          "packages/pieces/community/metabase/**/*.ts"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/pieces/community/metabase/src/index.ts
+++ b/packages/pieces/community/metabase/src/index.ts
@@ -1,0 +1,54 @@
+import {
+  createPiece,
+  PieceAuth,
+  Property,
+} from '@activepieces/pieces-framework';
+import { getQuestion } from './lib/actions/get-question';
+import { refreshSessionToken } from './lib/common';
+
+export const metabaseAuth = PieceAuth.CustomAuth({
+  description: 'Metabase authentication requires a username and password.',
+  required: true,
+  props: {
+    username: Property.ShortText({
+      displayName: 'User email',
+      required: true,
+    }),
+    password: PieceAuth.SecretText({
+      displayName: 'Password',
+      required: true,
+    }),
+    baseUrl: Property.ShortText({
+      displayName: 'Metabase API base URL',
+      required: true,
+    }),
+    encryptionKey: PieceAuth.SecretText({
+      displayName: 'Encryption key (for the session token)',
+      description: 'Generate one with `openssl rand -hex 16`',
+      required: true,
+    }),
+  },
+
+  validate: async ({ auth }) => {
+    try {
+      await refreshSessionToken(auth);
+      return {
+        valid: true,
+      };
+    } catch (e) {
+      return {
+        valid: false,
+        error: 'Invalid API Key or Token',
+      };
+    }
+  },
+});
+export const metabase = createPiece({
+  displayName: 'Metabase',
+  auth: metabaseAuth,
+  minimumSupportedRelease: '0.9.0',
+  logoUrl: 'https://cdn.activepieces.com/pieces/metabase.png',
+  authors: ['AdamSelene'],
+  actions: [getQuestion],
+  triggers: [],
+});

--- a/packages/pieces/community/metabase/src/lib/actions/get-question.ts
+++ b/packages/pieces/community/metabase/src/lib/actions/get-question.ts
@@ -1,0 +1,65 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { queryApiAndHandleRefresh } from '../common';
+import { metabaseAuth } from '../..';
+import { HttpMethod } from '@activepieces/pieces-common';
+
+interface MetabaseParam {
+  id: string;
+  target: unknown[];
+  type: string[];
+  slug: string;
+}
+
+export const getQuestion = createAction({
+  name: 'getQuestion',
+  auth: metabaseAuth,
+  requireAuth: true,
+  displayName: 'Get question',
+  description: 'Fetch the results of a Metabase question',
+  props: {
+    questionId: Property.ShortText({
+      displayName: 'Metabase question ID',
+      required: true,
+    }),
+    parameters: Property.Object({
+      displayName: 'Parameters (slug name -> value)',
+      required: false,
+    }),
+  },
+  async run({ auth, store, propsValue }) {
+    const card = await queryApiAndHandleRefresh(
+      { endpoint: `card/${propsValue.questionId}`, method: HttpMethod.GET },
+      auth,
+      store
+    );
+    const parameters = card['parameters'] as MetabaseParam[];
+
+    return queryApiAndHandleRefresh(
+      {
+        endpoint: `card/${propsValue.questionId}/query`,
+        method: HttpMethod.POST,
+        body: {
+          collection_preview: false,
+          ignore_cache: false,
+          parameters: parameters
+            .filter(
+              (param) =>
+                propsValue.parameters &&
+                propsValue.parameters[param.slug] !== undefined
+            )
+            .map((param) => {
+              return {
+                id: param.id,
+                target: param.target,
+                type: param.type,
+                value:
+                  propsValue.parameters && propsValue.parameters[param.slug],
+              };
+            }),
+        },
+      },
+      auth,
+      store
+    );
+  },
+});

--- a/packages/pieces/community/metabase/src/lib/common.ts
+++ b/packages/pieces/community/metabase/src/lib/common.ts
@@ -1,0 +1,135 @@
+import crypto from 'crypto';
+import {
+  httpClient,
+  HttpError,
+  HttpHeaders,
+  HttpMethod,
+  HttpRequest,
+  QueryParams,
+} from '@activepieces/pieces-common';
+import {
+  CustomAuthProps,
+  StaticPropsValue,
+  Store,
+  StoreScope,
+} from '@activepieces/pieces-framework';
+import { isNil } from '@activepieces/shared';
+
+type EncryptedObject = {
+  iv: string;
+  data: string;
+};
+
+const algorithm = 'aes-256-cbc';
+const ivLength = 16;
+const SESSION_TOKEN_KEY = '_session_token';
+
+function encryptString(inputString: string, key: string): EncryptedObject {
+  const iv = crypto.randomBytes(ivLength); // Generate a random initialization vector
+  const cipher = crypto.createCipheriv(
+    algorithm,
+    Buffer.from(key, 'binary'),
+    iv
+  ); // Create a cipher with the key and initialization vector
+  let encrypted = cipher.update(inputString, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  return {
+    iv: iv.toString('hex'),
+    data: encrypted,
+  };
+}
+
+function decryptString(encryptedObject: EncryptedObject, key: string): string {
+  const iv = Buffer.from(encryptedObject.iv, 'hex');
+  const decipher = crypto.createDecipheriv(
+    algorithm,
+    Buffer.from(key!, 'binary'),
+    iv
+  );
+  let decrypted = decipher.update(encryptedObject.data, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}
+
+export async function refreshSessionToken(
+  auth: StaticPropsValue<CustomAuthProps>
+) {
+  const { username, password, baseUrl } = auth;
+
+  const request: HttpRequest = {
+    method: HttpMethod.POST,
+    url: `${baseUrl}/api/session`,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ username, password }),
+  };
+  const tokenResponse = await httpClient.sendRequest(request);
+  return tokenResponse.body['id'];
+}
+
+async function storeSessionToken(
+  sessionToken: string,
+  encryptionKey: string,
+  store: Store
+) {
+  return store.put(
+    SESSION_TOKEN_KEY,
+    encryptString(sessionToken, encryptionKey as string),
+    StoreScope.FLOW
+  );
+}
+
+export async function queryApiAndHandleRefresh(
+  params: {
+    endpoint: string;
+    method: HttpMethod;
+    queryParams?: QueryParams;
+    headers?: HttpHeaders;
+    body?: object;
+  },
+  auth: StaticPropsValue<CustomAuthProps>,
+  store: Store
+) {
+  const { baseUrl, encryptionKey } = auth;
+  let sessionToken;
+  const encryptedToken = await store.get(SESSION_TOKEN_KEY, StoreScope.FLOW);
+  if (isNil(encryptedToken)) {
+    sessionToken = await refreshSessionToken(auth);
+    await storeSessionToken(sessionToken, encryptionKey as string, store);
+  } else {
+    try {
+      sessionToken = decryptString(
+        encryptedToken as EncryptedObject,
+        encryptionKey as string
+      );
+    } catch (e) {
+      // This can happen when e.g. the connection / encryption key has changed
+      sessionToken = await refreshSessionToken(auth);
+      await storeSessionToken(sessionToken, encryptionKey as string, store);
+    }
+  }
+
+  const request: HttpRequest = {
+    method: params.method,
+    url: `${baseUrl}/api/${params.endpoint}`,
+    queryParams: params.queryParams,
+    headers: {
+      ...params.headers,
+      'Content-Type': 'application/json',
+      'X-Metabase-Session': sessionToken,
+    },
+    body: JSON.stringify(params.body),
+  };
+  try {
+    return (await httpClient.sendRequest(request)).body;
+  } catch (error) {
+    const httpError = error as HttpError;
+    if (httpError.response.status === 401) {
+      const sessionToken = await refreshSessionToken(auth);
+      await storeSessionToken(sessionToken, encryptionKey as string, store);
+      return (await httpClient.sendRequest(request)).body;
+    }
+    throw error;
+  }
+}

--- a/packages/pieces/community/metabase/tsconfig.json
+++ b/packages/pieces/community/metabase/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true
+  },
+  "files": [],
+  "include": [],
+  "exclude": ["node_modules"],
+
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ],
+}

--- a/packages/pieces/community/metabase/tsconfig.lib.json
+++ b/packages/pieces/community/metabase/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts", "node_modules"],
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## What does this PR do?

Add Metabase piece with action to get results from a "question"
Metabase auth scheme requires a session token (with a fixed duration) that is delivered by a specific endpoint (using email + password)
The Piece will automatically get the token and refresh it when a HTTP 401 error is received, as per Metabase documentation

The token is encrypted (using code which is very similar to `encryption.ts`) and stored at the Project scope

https://www.metabase.com/learn/administration/metabase-api#authenticate-your-requests-with-a-session-token

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<img width="383" alt="Capture d’écran 2024-02-12 à 00 43 33" src="https://github.com/alan-eu/activepieces/assets/79495/60d8f2df-b160-4f5f-b3e4-76597e3fa2a3">

<img width="579" alt="Capture d’écran 2024-02-12 à 00 44 36" src="https://github.com/alan-eu/activepieces/assets/79495/99fa1238-ce9a-4cf2-9baa-17dcf3d4b5e8">

