### PR TITLE
feat: display editor in versions history

### DIFF
--- a/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
+++ b/packages/server/api/src/app/flows/flow-version/flow-version.service.ts
@@ -201,7 +201,12 @@ export const flowVersionService = {
             },
         })
         const paginationResult = await paginator.paginate(
-            flowVersionRepo().createQueryBuilder('flow_version').where({
+            flowVersionRepo().createQueryBuilder('flow_version').innerJoinAndMapOne(
+                'flow_version.updatedByUser',
+                'user',
+                'user',
+                'flow_version.updatedBy = "user"."id"',
+            ).where({
                 flowId,
             }),
         )

--- a/packages/shared/src/lib/flows/flow-version.ts
+++ b/packages/shared/src/lib/flows/flow-version.ts
@@ -2,6 +2,7 @@ import { BaseModelSchema, Nullable } from '../common/base-model'
 import { ApId } from '../common/id-generator'
 import { Trigger } from './triggers/trigger'
 import { Static, Type } from '@sinclair/typebox'
+import { User } from '../user'
 
 export type FlowVersionId = ApId
 
@@ -28,6 +29,8 @@ export const FlowVersionMetadata = Type.Object({
     displayName: Type.String(),
     valid: Type.Boolean(),
     state: Type.Enum(FlowVersionState),
+    updatedBy: Nullable(Type.String()),
+    updatedByUser: Nullable(User),
 })
 
 export type FlowVersionMetadata = Static<typeof FlowVersionMetadata>

--- a/packages/ui/feature-builder-left-sidebar/src/lib/components/version-history/version-history.component.html
+++ b/packages/ui/feature-builder-left-sidebar/src/lib/components/version-history/version-history.component.html
@@ -9,7 +9,7 @@
                         <div class="ap-text-body">{{version.created |date:'mediumDate'
                             }}, {{version.created |date:'shortTime' }} </div>
                         <div class=" ap-text-description ap-typography-subtitle-2 ">Version
-                            #{{flowVersions.data.length - idx}}</div>
+                            #{{flowVersions.data.length - idx}} ({{version.updatedByUser?.email}})</div>
                     </div>
 
                     <div class="ap-flex-grow"></div>

--- a/packages/ui/feature-builder-left-sidebar/src/lib/components/version-history/version-history.component.ts
+++ b/packages/ui/feature-builder-left-sidebar/src/lib/components/version-history/version-history.component.ts
@@ -1,4 +1,8 @@
-import { FlowOperationType, FlowVersion, SeekPage } from '@activepieces/shared';
+import {
+  FlowOperationType,
+  FlowVersionMetadata,
+  SeekPage,
+} from '@activepieces/shared';
 import { FlowService } from '@activepieces/ui/common';
 import {
   BuilderSelectors,
@@ -32,13 +36,13 @@ import { MatDialog } from '@angular/material/dialog';
 })
 export class VersionHistoryComponent {
   sideBarDisplayName = $localize`Versions`;
-  flowVersions$: Observable<SeekPage<FlowVersion>>;
+  flowVersions$: Observable<SeekPage<FlowVersionMetadata>>;
   useAsDraft$?: Observable<void>;
   rewritingDraft = false;
-  publishedVersion$: Observable<FlowVersion | undefined>;
+  publishedVersion$: Observable<FlowVersionMetadata | undefined>;
   draftVersionId$: Observable<string>;
   displayVersion$?: Observable<unknown>;
-  viewedVersion$: Observable<FlowVersion>;
+  viewedVersion$: Observable<FlowVersionMetadata>;
   constructor(
     private flowService: FlowService,
     private store: Store,
@@ -58,7 +62,7 @@ export class VersionHistoryComponent {
     );
   }
 
-  useAsDraft(flowVersion: FlowVersion, versionNumber: number) {
+  useAsDraft(flowVersion: FlowVersionMetadata, versionNumber: number) {
     if (this.rewritingDraft) {
       return;
     }
@@ -109,7 +113,7 @@ export class VersionHistoryComponent {
     );
   }
 
-  displayVersion(flowVersion: FlowVersion) {
+  displayVersion(flowVersion: FlowVersionMetadata) {
     this.displayVersion$ = forkJoin({
       flow: this.flowService.get(flowVersion.flowId, flowVersion.id),
       published: this.store


### PR DESCRIPTION
## What does this PR do?
Add the editor's email in a flow's version history

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

![Capture d’écran 2024-02-17 à 01 32 42](https://github.com/alan-eu/activepieces/assets/79495/09901290-02ea-4be2-85b6-7b482e55cd75)

