### PR TITLE
feat(dust): add action for upserting a document into a database

### DIFF
--- a/packages/pieces/community/dust/src/index.ts
+++ b/packages/pieces/community/dust/src/index.ts
@@ -5,6 +5,7 @@ import {
 } from '@activepieces/pieces-framework';
 import { createConversation } from './lib/actions/create-conversation';
 import { replyToConversation } from './lib/actions/reply-to-conversation';
+import { upsertDocument } from './lib/actions/upsert-document';
 
 export const dustAuth = PieceAuth.CustomAuth({
   description: 'Dust authentication requires an API key.',
@@ -33,6 +34,6 @@ export const dust = createPiece({
   minimumSupportedRelease: '0.9.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/dust.png',
   authors: ['AdamSelene'],
-  actions: [createConversation, replyToConversation],
+  actions: [createConversation, replyToConversation, upsertDocument],
   triggers: [],
 });

--- a/packages/pieces/community/dust/src/lib/actions/upsert-document.ts
+++ b/packages/pieces/community/dust/src/lib/actions/upsert-document.ts
@@ -1,0 +1,74 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import {
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+import { DUST_BASE_URL } from '../common';
+import { dustAuth } from '../..';
+import mimeTypes from 'mime-types';
+
+export const upsertDocument = createAction({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'addDocument',
+  displayName: 'Add or update document',
+  description:
+    'Insert a new document to a Data Source (or update an existing one)',
+  auth: dustAuth,
+  props: {
+    datasource: Property.ShortText({
+      displayName: 'Data Source name',
+      required: true,
+    }),
+    documentId: Property.ShortText({
+      displayName: 'Document ID',
+      description: 'The ID of the document you want to insert or replace',
+      required: true,
+    }),
+    content: Property.LongText({
+      displayName: 'Document content',
+      description: 'The text content of the document',
+      required: true,
+    }),
+    sourceUrl: Property.ShortText({
+      displayName: 'Source URL',
+      description: 'The source URL of the document (when cited)',
+      required: false,
+    }),
+    title: Property.ShortText({
+      displayName: 'Document title',
+      description: 'User-friendly title of the document',
+      required: false,
+    }),
+    tags: Property.Array({
+      displayName: 'Tags',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const tags = propsValue.title
+      ? [`title:${propsValue.title}`, ...(propsValue.tags as string[])]
+      : (propsValue.tags as string[]);
+    const request: HttpRequest = {
+      method: HttpMethod.POST,
+      url: `${DUST_BASE_URL}/${auth.workspaceId}/data_sources/${
+        propsValue.datasource
+      }/documents/${encodeURIComponent(propsValue.documentId)}`,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${auth.apiKey}`,
+      },
+      body: JSON.stringify(
+        {
+          text: propsValue.content,
+          source_url: propsValue.sourceUrl,
+          tags: tags,
+        },
+        (key, value) => (typeof value === 'undefined' ? null : value)
+      ),
+    };
+
+    const response = await httpClient.sendRequest(request);
+    return response.body;
+  },
+});


### PR DESCRIPTION
## What does this PR do?
Allow upserting a document into a Dust data source (so it can be indexed and used by assistants)

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

