### PR TITLE
feat(dust): add support for fragments

### DIFF
--- a/packages/pieces/community/dust/package.json
+++ b/packages/pieces/community/dust/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-dust",
-  "version": "0.0.4"
+  "version": "0.1.0"
 }

--- a/packages/pieces/community/dust/src/index.ts
+++ b/packages/pieces/community/dust/src/index.ts
@@ -6,6 +6,7 @@ import {
 import { createConversation } from './lib/actions/create-conversation';
 import { replyToConversation } from './lib/actions/reply-to-conversation';
 import { upsertDocument } from './lib/actions/upsert-document';
+import { addFragmentToConversation } from './lib/actions/add-fragment-to-conversation';
 
 export const dustAuth = PieceAuth.CustomAuth({
   description: 'Dust authentication requires an API key.',
@@ -35,6 +36,11 @@ export const dust = createPiece({
   minimumSupportedRelease: '0.9.0',
   logoUrl: 'https://cdn.activepieces.com/pieces/dust.png',
   authors: ['AdamSelene', 'abuaboud'],
-  actions: [createConversation, replyToConversation, upsertDocument],
+  actions: [
+    createConversation,
+    replyToConversation,
+    addFragmentToConversation,
+    upsertDocument,
+  ],
   triggers: [],
 });

--- a/packages/pieces/community/dust/src/lib/actions/add-fragment-to-conversation.ts
+++ b/packages/pieces/community/dust/src/lib/actions/add-fragment-to-conversation.ts
@@ -1,0 +1,49 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { dustAuth } from '../..';
+import { DUST_BASE_URL, getConversationContent } from '../common';
+import {
+  httpClient,
+  HttpMethod,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+
+export const addFragmentToConversation = createAction({
+  // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
+  name: 'addFragmentToConversation',
+  displayName: 'Add fragment to conversation',
+  description:
+    'Create a new content fragment in a conversation. Content fragments are pieces of information that can be inserted in conversations and are passed as context to assistants to when they generate an answer.',
+  auth: dustAuth,
+  props: {
+    conversationId: Property.ShortText({
+      displayName: 'Conversation ID',
+      required: true,
+    }),
+    fragment: Property.File({ displayName: 'Fragment', required: true }),
+    fragmentName: Property.ShortText({
+      displayName: 'Fragment name',
+      required: false,
+    }),
+  },
+  async run({ auth, propsValue }) {
+    const request: HttpRequest = {
+      method: HttpMethod.POST,
+      url: `${DUST_BASE_URL}/${auth.workspaceId}/assistant/conversations/${propsValue.conversationId}/content_fragments`,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${auth.apiKey}`,
+      },
+      body: JSON.stringify(
+        {
+          content: propsValue.fragment.data.toString('utf-8'),
+          title: propsValue.fragmentName || propsValue.fragment.filename,
+          contentType: 'file_attachment',
+          context: null,
+          url: null,
+        },
+        (key, value) => (typeof value === 'undefined' ? null : value)
+      ),
+    };
+    return (await httpClient.sendRequest(request)).body;
+  },
+});

--- a/packages/pieces/community/dust/src/lib/common.ts
+++ b/packages/pieces/community/dust/src/lib/common.ts
@@ -90,6 +90,7 @@ export async function getConversationContent(
     await new Promise((f) => setTimeout(f, 10000));
 
     conversation = await getConversation(conversationId);
+    console.log('STATUS', conversation.body);
     retries += 1;
   }
 


### PR DESCRIPTION
## What does this PR do?
Add support for fragments, i.e. additional context to pass to the assistant
- initial fragment can be passed when creating a new conversation
- new action to add a fragment to an existing conversation

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

