### PR TITLE
fix(google-drive): add missing option to support team drives for duplicate file action

### DIFF
--- a/packages/pieces/community/google-drive/package.json
+++ b/packages/pieces/community/google-drive/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-drive",
-  "version": "0.5.19"
+  "version": "0.5.20"
 }

--- a/packages/pieces/community/google-drive/src/lib/action/add-permission.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/add-permission.action.ts
@@ -19,7 +19,7 @@ export const addPermission = createAction({
             validators: [Validators.email],
             description: 'The email address of the user to update permissions for',
             required: true,
-        }),        
+        }),
         permission_name : Property.StaticDropdown({
             displayName: 'Role',
             description: 'The role to grant to user. See more at: https://developers.google.com/drive/api/guides/ref-roles',
@@ -46,7 +46,7 @@ export const addPermission = createAction({
                     label: 'Reader',
                     value: 'reader',
                 },
-                
+
             ]
             }
         }),
@@ -55,7 +55,7 @@ export const addPermission = createAction({
             description: 'Send an email to the user to notify them of the new permissions',
             required: true,
         }),
-        
+
        },
 
     async run(context) {
@@ -73,7 +73,7 @@ export const addPermission = createAction({
             fileId: fileId,
             sendNotificationEmail: send_invitation_email
         });
-        
+
         return result.data;
     }
 });

--- a/packages/pieces/community/google-drive/src/lib/action/duplicate-file.action.ts
+++ b/packages/pieces/community/google-drive/src/lib/action/duplicate-file.action.ts
@@ -2,6 +2,7 @@ import { Property, createAction } from '@activepieces/pieces-framework';
 import { google } from 'googleapis';
 import { OAuth2Client } from 'googleapis-common';
 import { googleDriveAuth } from '../../index';
+import { common } from '../common';
 
 export const duplicateFileAction = createAction({
   displayName: 'Duplicate File',
@@ -24,6 +25,7 @@ export const duplicateFileAction = createAction({
       description: 'The ID of the folder where the file will be duplicated',
       required: true,
     }),
+    include_team_drives: common.properties.include_team_drives,
   },
   async run(context) {
     const authClient = new OAuth2Client();
@@ -39,6 +41,7 @@ export const duplicateFileAction = createAction({
       fileId,
       auth: authClient,
       requestBody: { name: nameForNewFile, parents: [parentFolderId] },
+      supportsAllDrives: context.propsValue.include_team_drives,
     });
 
     if (response.status !== 200) {

--- a/packages/pieces/community/google-drive/src/lib/common/index.ts
+++ b/packages/pieces/community/google-drive/src/lib/common/index.ts
@@ -1,123 +1,150 @@
-import { httpClient, HttpMethod, AuthenticationType, HttpRequest } from "@activepieces/pieces-common";
-import { Property, OAuth2PropertyValue } from "@activepieces/pieces-framework";
-import dayjs from "dayjs";
+import {
+  httpClient,
+  HttpMethod,
+  AuthenticationType,
+  HttpRequest,
+} from '@activepieces/pieces-common';
+import { Property, OAuth2PropertyValue } from '@activepieces/pieces-framework';
+import dayjs from 'dayjs';
 
 export const common = {
-    properties: {
-        parentFolder: Property.Dropdown({
-            displayName: "Parent Folder",
-            required: false,
-            refreshers: ['include_team_drives'],
-            options: async ({ auth,include_team_drives }) => {
-              if (!auth) {
-                return {
-                  disabled: true,
-                  options: [],
-                  placeholder: 'Please authenticate first'
-                }
-              }              
-              const authProp: OAuth2PropertyValue = auth as OAuth2PropertyValue;
-              let folders : { id: string, name: string }[] = [];
-              let pageToken = null;
-              do{
-                const request: HttpRequest = {
-                  method: HttpMethod.GET,
-                  url: `https://www.googleapis.com/drive/v3/files`,
-                  queryParams: {
-                    q: "mimeType='application/vnd.google-apps.folder' and trashed = false",
-                    includeItemsFromAllDrives: include_team_drives ? "true" : "false",
-                    supportsAllDrives: "true"
-                  },
-                  authentication: {
-                    type: AuthenticationType.BEARER_TOKEN,
-                    token: authProp!['access_token'],
-                  }
-                };
-                if(pageToken){
-                  if(request.queryParams !== undefined){
-                    request.queryParams['pageToken'] = pageToken;
-                  }
-                }
-                try{
-                  const response = await httpClient.sendRequest<{
-                    files: { id: string, name: string }[],
-                    nextPageToken: string
-                  }>(request);
-                  folders = folders.concat(response.body.files);
-                  pageToken = response.body.nextPageToken;
-                }catch(e){
-                  throw new Error(`Failed to get folders\nError:${e}`);
-                }
-              }while(pageToken);
-    
-              return {
-                disabled: false,
-                options: folders.map((folder: { id: string, name: string }) => {
-                  return {
-                    label: folder.name,
-                    value: folder.id
-                  }
-                })
-              };
+  properties: {
+    parentFolder: Property.Dropdown({
+      displayName: 'Parent Folder',
+      required: false,
+      refreshers: ['include_team_drives'],
+      options: async ({ auth, include_team_drives }) => {
+        if (!auth) {
+          return {
+            disabled: true,
+            options: [],
+            placeholder: 'Please authenticate first',
+          };
+        }
+        const authProp: OAuth2PropertyValue = auth as OAuth2PropertyValue;
+        let folders: { id: string; name: string }[] = [];
+        let pageToken = null;
+        do {
+          const request: HttpRequest = {
+            method: HttpMethod.GET,
+            url: `https://www.googleapis.com/drive/v3/files`,
+            queryParams: {
+              q: "mimeType='application/vnd.google-apps.folder' and trashed = false",
+              includeItemsFromAllDrives: include_team_drives ? 'true' : 'false',
+              supportsAllDrives: 'true',
+            },
+            authentication: {
+              type: AuthenticationType.BEARER_TOKEN,
+              token: authProp!['access_token'],
+            },
+          };
+          if (pageToken) {
+            if (request.queryParams !== undefined) {
+              request.queryParams['pageToken'] = pageToken;
             }
+          }
+          try {
+            const response = await httpClient.sendRequest<{
+              files: { id: string; name: string }[];
+              nextPageToken: string;
+            }>(request);
+            folders = folders.concat(response.body.files);
+            pageToken = response.body.nextPageToken;
+          } catch (e) {
+            throw new Error(`Failed to get folders\nError:${e}`);
+          }
+        } while (pageToken);
+
+        return {
+          disabled: false,
+          options: folders.map((folder: { id: string; name: string }) => {
+            return {
+              label: folder.name,
+              value: folder.id,
+            };
           }),
-          include_team_drives: Property.Checkbox({
-            displayName: 'Include Team Drives',
-            description: 'Determines if folders from Team Drives should be included in the results.',
-            defaultValue: false,
-            required: false,
-        })
+        };
+      },
+    }),
+    include_team_drives: Property.Checkbox({
+      displayName: 'Include Team Drives',
+      description:
+        'Determines if folders from Team Drives should be included in the results.',
+      defaultValue: false,
+      required: false,
+    }),
+  },
+
+  async getFiles(
+    auth: OAuth2PropertyValue,
+    search?: {
+      parent?: string;
+      createdTime?: string | number | Date;
+      createdTimeOp?: string;
     },
+    order?: string
+  ) {
+    const q: string[] = [];
+    if (search?.parent) q.push(`'${search.parent}' in parents`);
+    if (search?.createdTime)
+      q.push(
+        `createdTime ${search.createdTimeOp ?? '>'} '${dayjs(
+          search.createdTime
+        ).format()}'`
+      );
+    q.push(`trashed = false`);
+    const response = await httpClient.sendRequest<{
+      files: { id: string; name: string }[];
+    }>({
+      method: HttpMethod.GET,
+      url: `https://www.googleapis.com/drive/v3/files`,
+      queryParams: {
+        q: q.join(' and '),
+        fields: 'files(id, name, mimeType, webViewLink, kind)',
+        orderBy: order ?? 'createdTime asc',
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.access_token,
+      },
+    });
 
-    async getFiles(auth: OAuth2PropertyValue, search?: {
-        parent?: string,
-        createdTime?: string | number | Date,
-        createdTimeOp?: string
-    }, order?: string) {
-        const q: string[] = [];
-        if (search?.parent) q.push(`'${search.parent}' in parents`);
-        if (search?.createdTime) q.push(`createdTime ${search.createdTimeOp ?? '>'} '${dayjs(search.createdTime).format()}'`);
-        q.push(`trashed = false`)
-        const response = await httpClient.sendRequest<{ files: { id: string, name: string }[] }>({
-            method: HttpMethod.GET,
-            url: `https://www.googleapis.com/drive/v3/files`,
-            queryParams: {
-                q: q.join(' and '),
-                fields: 'files(id, name, mimeType, webViewLink, kind)',
-                orderBy: order ?? 'createdTime asc'
-            },
-            authentication: {
-                type: AuthenticationType.BEARER_TOKEN,
-                token: auth.access_token,
-            }
-        });
+    return response.body.files;
+  },
 
-        return response.body.files;
+  async getFolders(
+    auth: OAuth2PropertyValue,
+    search?: {
+      parent?: string;
+      createdTime?: string | number | Date;
+      createdTimeOp?: string;
     },
+    order?: string
+  ) {
+    const q: string[] = [`mimeType='application/vnd.google-apps.folder'`];
+    if (search?.parent) q.push(`'${search.parent}' in parents`);
+    if (search?.createdTime)
+      q.push(
+        `createdTime ${search.createdTimeOp ?? '>'} '${dayjs(
+          search.createdTime
+        ).format()}'`
+      );
+    q.push(`trashed = false`);
+    const response = await httpClient.sendRequest<{
+      files: { id: string; name: string }[];
+    }>({
+      method: HttpMethod.GET,
+      url: `https://www.googleapis.com/drive/v3/files`,
+      queryParams: {
+        q: q.join(' and '),
+        orderBy: order ?? 'createdTime asc',
+      },
+      authentication: {
+        type: AuthenticationType.BEARER_TOKEN,
+        token: auth.access_token,
+      },
+    });
 
-    async getFolders(auth: OAuth2PropertyValue, search?: {
-        parent?: string,
-        createdTime?: string | number | Date,
-        createdTimeOp?: string
-    }, order?: string) {
-        const q: string[] = [`mimeType='application/vnd.google-apps.folder'`];
-        if (search?.parent) q.push(`'${search.parent}' in parents`);
-        if (search?.createdTime) q.push(`createdTime ${search.createdTimeOp ?? '>'} '${dayjs(search.createdTime).format()}'`);
-        q.push(`trashed = false`)
-        const response = await httpClient.sendRequest<{ files: { id: string, name: string }[] }>({
-            method: HttpMethod.GET,
-            url: `https://www.googleapis.com/drive/v3/files`,
-            queryParams: {
-                q: q.join(' and '),
-                orderBy: order ?? 'createdTime asc'
-            },
-            authentication: {
-                type: AuthenticationType.BEARER_TOKEN,
-                token: auth.access_token,
-            }
-        });
-
-        return response.body.files;
-    },
-
-}
+    return response.body.files;
+  },
+};


### PR DESCRIPTION
## What does this PR do?
Add missing option to support team drives when duplicating a file

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

