### PR TITLE
fix(metabase): fix session token refresh

### DIFF
--- a/packages/pieces/community/metabase/src/lib/common.ts
+++ b/packages/pieces/community/metabase/src/lib/common.ts
@@ -128,6 +128,7 @@ export async function queryApiAndHandleRefresh(
     if (httpError.response.status === 401) {
       const sessionToken = await refreshSessionToken(auth);
       await storeSessionToken(sessionToken, encryptionKey as string, store);
+      request.headers!['X-Metabase-Session'] = sessionToken;
       return (await httpClient.sendRequest(request)).body;
     }
     throw error;


### PR DESCRIPTION
## What does this PR do?
Metabase session token is automatically refreshed when a 401 error is encountered and the original query is automatically retried.
But the retry would use the previous (invalid) token, thus yielding another 401
This PR updates the retry payload to actually use the new token :facepalm:


