### PR TITLE
feat(gmail): allow custom from address

### DIFF
--- a/packages/pieces/community/gmail/package.json
+++ b/packages/pieces/community/gmail/package.json
@@ -1,4 +1,4 @@
 {
 	"name": "@activepieces/piece-gmail",
-	"version": "0.7.1"
+	"version": "0.7.2"
 }

--- a/packages/pieces/community/gmail/src/lib/actions/send-email-action.ts
+++ b/packages/pieces/community/gmail/src/lib/actions/send-email-action.ts
@@ -70,6 +70,12 @@ export const gmailSendEmailAction = createAction({
       displayName: 'Sender Name',
       required: false,
     }),
+    from: Property.ShortText({
+      displayName: 'Sender Email',
+      description:
+        "The address must be listed in your GMail account's settings",
+      required: false,
+    }),
     attachment: Property.File({
       displayName: 'Attachment',
       description: 'File to attach to the email you want to send',
@@ -145,11 +151,14 @@ export const gmailSendEmailAction = createAction({
       threadId = messages.data.messages?.[0].threadId;
     }
 
-    const senderEmail = (
-      await google.oauth2({ version: 'v2', auth: authClient }).userinfo.get()
-    ).data.email;
-    if (senderEmail && context.propsValue['sender_name']) {
-      mailOptions.from = `${context.propsValue['sender_name']} <${senderEmail}>`;
+    const senderEmail =
+      context.propsValue.from ||
+      (await google.oauth2({ version: 'v2', auth: authClient }).userinfo.get())
+        .data.email;
+    if (senderEmail) {
+      mailOptions.from = context.propsValue.sender_name
+        ? `${context.propsValue['sender_name']} <${senderEmail}>`
+        : senderEmail;
     }
 
     if (attachment) {


### PR DESCRIPTION
## What does this PR do?
GMail accounts can be configured to send from multiple email addresses - this change allows us to use one of them

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

