### PR TITLE
feat: add usergroups:read Slack permission

### DIFF
--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.7.12"
+  "version": "0.7.13"
 }

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -55,6 +55,7 @@ export const slackAuth = PieceAuth.OAuth2({
     'files:read',
     'users:read.email',
     'reactions:write',
+    'usergroups:read'
   ],
 });
 


### PR DESCRIPTION
## What does this PR do?

In [this flow](https://automation-staging.alan.com/projects/sLXgp6v5K9RSAHIKP025R/flows/Ok66SEyBmiu2Wfh7RWgIr), I'm trying to get the members of a slack group (@\care_spain_oncall specifically) using a custom API call, but I get the following response from Slack:
```
body:{4 items
ok:false
error:"missing_scope"
needed:"usergroups:read"
provided:"reactions:read,channels:read,channels:manage,channels:history,chat:write,groups:read,groups:write,mpim:read,mpim:write,im:write,users:read,files:write,files:read,users:read.email,reactions:write,chat:write.customize,chat:write.public,groups:history,mpim:history,im:read,im:history"
}
```
In this PR, I've added the necessary permission to allow the API call.
