### PR TITLE
feat(rounded-studio): add piece with custom api call action

### DIFF
--- a/packages/pieces/community/rounded-studio/.eslintrc.json
+++ b/packages/pieces/community/rounded-studio/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../../.eslintrc.base.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/pieces/community/rounded-studio/README.md
+++ b/packages/pieces/community/rounded-studio/README.md
@@ -1,0 +1,7 @@
+# pieces-rounded-studio
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build pieces-rounded-studio` to build the library.

--- a/packages/pieces/community/rounded-studio/package.json
+++ b/packages/pieces/community/rounded-studio/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@activepieces/piece-rounded-studio",
+  "version": "0.0.1"
+}

--- a/packages/pieces/community/rounded-studio/project.json
+++ b/packages/pieces/community/rounded-studio/project.json
@@ -1,0 +1,45 @@
+{
+  "name": "pieces-rounded-studio",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/pieces/community/rounded-studio/src",
+  "projectType": "library",
+  "release": {
+    "version": {
+      "generatorOptions": {
+        "packageRoot": "dist/{projectRoot}",
+        "currentVersionResolver": "git-tag"
+      }
+    }
+  },
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{options.outputPath}"
+      ],
+      "options": {
+        "outputPath": "dist/packages/pieces/community/rounded-studio",
+        "tsConfig": "packages/pieces/community/rounded-studio/tsconfig.lib.json",
+        "packageJson": "packages/pieces/community/rounded-studio/package.json",
+        "main": "packages/pieces/community/rounded-studio/src/index.ts",
+        "assets": [
+          "packages/pieces/community/rounded-studio/*.md"
+        ],
+        "buildableProjectDepsInPackageJsonType": "dependencies",
+        "updateBuildableProjectDepsInPackageJson": true
+      }
+    },
+    "nx-release-publish": {
+      "options": {
+        "packageRoot": "dist/{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": [
+        "{options.outputFile}"
+      ]
+    }
+  }
+}

--- a/packages/pieces/community/rounded-studio/src/index.ts
+++ b/packages/pieces/community/rounded-studio/src/index.ts
@@ -1,0 +1,29 @@
+import { createPiece, PieceAuth } from "@activepieces/pieces-framework";
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+
+export const roundedStudioAuth = PieceAuth.SecretText({
+  displayName: 'API Key',
+  required: true,
+  description: 'Please enter the API Key obtained from Rounded Studio.',
+});
+
+export const roundedStudio = createPiece({
+  displayName: "Rounded-studio",
+  auth: roundedStudioAuth,
+  minimumSupportedRelease: '0.36.1',
+  logoUrl: "https://cdn.activepieces.com/pieces/rounded-studio.png",
+  authors: ["perrine-pullicino-alan"],
+  actions: [
+    createCustomApiCallAction({
+      baseUrl: () => {
+        return "https://api.callrounded.com/v1";
+      },
+      auth: roundedStudioAuth,
+      authMapping: async (auth) => ({
+        'x-app': 'activepieces',
+        'api_key': auth as string,
+      }),
+    })
+  ],
+    triggers: [],
+});

--- a/packages/pieces/community/rounded-studio/tsconfig.json
+++ b/packages/pieces/community/rounded-studio/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/pieces/community/rounded-studio/tsconfig.lib.json
+++ b/packages/pieces/community/rounded-studio/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -567,6 +567,9 @@
       "@activepieces/piece-robolly": [
         "packages/pieces/community/robolly/src/index.ts"
       ],
+      "@activepieces/piece-rounded-studio": [
+        "packages/pieces/community/rounded-studio/src/index.ts"
+      ],
       "@activepieces/piece-rss": ["packages/pieces/community/rss/src/index.ts"],
       "@activepieces/piece-saastic": [
         "packages/pieces/community/saastic/src/index.ts"


### PR DESCRIPTION
## What does this PR do?

Adds a new activepieces piece for [Rounded Studio](https://rounded.studio/) which allows only for a Custom API Call.

### Explain How the Feature Works

https://github.com/user-attachments/assets/4d45b595-d2c4-4481-ba96-16c00089ec2e

Fixes Q-1278

[Q-1278](https://linear.app/alan-eu/issue/Q-1278/active-pieces-added-roundedstudio-piece-for-custom-api-calls)