### PR TITLE
feat(dust): upload file piece

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@dnd-kit/core": "6.1.0",
         "@dnd-kit/modifiers": "7.0.0",
         "@dnd-kit/sortable": "8.0.0",
+        "@dust-tt/client": "1.0.41",
         "@fastify/basic-auth": "5.0.0",
         "@fastify/cors": "8.3.0",
         "@fastify/formbody": "7.4.0",
@@ -6006,6 +6007,20 @@
       },
       "peerDependencies": {
         "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dust-tt/client": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/@dust-tt/client/-/client-1.0.41.tgz",
+      "integrity": "sha512-tEXQhgY0E96sUpPmZ/iBr+VGKgUH9o3KXV4uIfXL58rlLGKyCq/gXYt1Y1jnb/vPv869cJrzg6gYSxVMtRalWQ==",
+      "dependencies": {
+        "axios": "^1.7.9",
+        "eventsource-parser": "^1.1.1",
+        "moment-timezone": "^0.5.46",
+        "zod": "^3.23.8"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@dnd-kit/core": "6.1.0",
     "@dnd-kit/modifiers": "7.0.0",
     "@dnd-kit/sortable": "8.0.0",
+    "@dust-tt/client": "1.0.41",
     "@fastify/basic-auth": "5.0.0",
     "@fastify/cors": "8.3.0",
     "@fastify/formbody": "7.4.0",

--- a/packages/pieces/community/dust/package.json
+++ b/packages/pieces/community/dust/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-dust",
-  "version": "0.1.7"
+  "version": "0.1.8"
 }

--- a/packages/pieces/community/dust/src/index.ts
+++ b/packages/pieces/community/dust/src/index.ts
@@ -8,7 +8,7 @@ import { replyToConversation } from './lib/actions/reply-to-conversation';
 import { upsertDocument } from './lib/actions/upsert-document';
 import { addFragmentToConversation } from './lib/actions/add-fragment-to-conversation';
 import { getConversation } from './lib/actions/get-conversation';
-
+import { uploadFile } from './lib/actions/upload-file';
 export const dustAuth = PieceAuth.CustomAuth({
   description: 'Dust authentication requires an API key.',
   required: true,
@@ -43,6 +43,7 @@ export const dust = createPiece({
     replyToConversation,
     addFragmentToConversation,
     upsertDocument,
+    uploadFile,
   ],
   triggers: [],
 });

--- a/packages/pieces/community/dust/src/lib/actions/create-conversation.ts
+++ b/packages/pieces/community/dust/src/lib/actions/create-conversation.ts
@@ -1,19 +1,15 @@
 import { createAction, Property } from '@activepieces/pieces-framework';
 import {
-  httpClient,
-  HttpMethod,
-  HttpRequest,
-} from '@activepieces/pieces-common';
-import {
-  DUST_BASE_URL,
   assistantProp,
   usernameProp,
   timezoneProp,
   getConversationContent,
   timeoutProp,
+  createClient,
 } from '../common';
-import { dustAuth } from '../..';
+import { dustAuth, DustAuthType } from '../..';
 import mime from 'mime-types';
+import { PublicPostConversationsRequestBody } from '@dust-tt/client';
 
 export const createConversation = createAction({
   // auth: check https://www.activepieces.com/docs/developers/piece-reference/authentication,
@@ -28,19 +24,28 @@ export const createConversation = createAction({
     title: Property.ShortText({ displayName: 'Title', required: false }),
     query: Property.LongText({ displayName: 'Query', required: false }),
     fragment: Property.File({ displayName: 'Fragment', required: false }),
+    fileId: Property.ShortText({
+      displayName: 'File ID',
+      required: false,
+      description:
+        'ID of the file to be added to the conversation (takes precedence over Fragment)',
+    }),
     fragmentName: Property.ShortText({
-      displayName: 'Fragment name',
+      displayName: 'Fragment/file name',
       required: false,
     }),
     timeout: timeoutProp,
   },
   async run({ auth, propsValue }) {
-    const payload: Record<string, any> = {
+    const client = createClient(auth as DustAuthType);
+
+    const payload: PublicPostConversationsRequestBody = {
       visibility: 'unlisted',
       title: propsValue.title || null,
     };
+
     if (propsValue.query) {
-      payload['message'] = {
+      payload.message = {
         content: propsValue.query,
         mentions: [{ configurationId: propsValue.assistant }],
         context: {
@@ -52,12 +57,18 @@ export const createConversation = createAction({
         },
       };
     }
-    if (propsValue.fragment) {
+
+    if (propsValue.fileId) {
+      payload.contentFragment = {
+        title: propsValue.fragmentName || '',
+        fileId: propsValue.fileId,
+      };
+    } else if (propsValue.fragment) {
       const mimeType = propsValue.fragmentName
         ? mime.lookup(propsValue.fragmentName) ||
           mime.lookup(propsValue.fragment.filename)
         : mime.lookup(propsValue.fragment.filename);
-      payload['contentFragment'] = {
+      payload.contentFragment = {
         title: propsValue.fragmentName || propsValue.fragment.filename,
         content: propsValue.fragment.data.toString('utf-8'),
         contentType: mimeType || 'text/plain',
@@ -66,19 +77,13 @@ export const createConversation = createAction({
       };
     }
 
-    const request: HttpRequest = {
-      method: HttpMethod.POST,
-      url: `${DUST_BASE_URL}/${auth.workspaceId}/assistant/conversations`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${auth.apiKey}`,
-      },
-      body: JSON.stringify(payload, (key, value) =>
-        typeof value === 'undefined' ? null : value
-      ),
-    };
-    const body = (await httpClient.sendRequest(request)).body;
-    const conversationId = body['conversation']['sId'];
+    const response = await client.createConversation(payload);
+
+    if (response.isErr()) {
+      throw new Error(`API Error: ${response.error.message}`);
+    }
+
+    const conversationId = response.value.conversation.sId;
     if (propsValue.query) {
       return await getConversationContent(
         conversationId,
@@ -86,7 +91,7 @@ export const createConversation = createAction({
         auth
       );
     } else {
-      return body;
+      return response.value;
     }
   },
 });

--- a/packages/pieces/community/dust/src/lib/actions/upload-file.ts
+++ b/packages/pieces/community/dust/src/lib/actions/upload-file.ts
@@ -1,0 +1,43 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+
+import { createClient } from '../common';
+import { dustAuth, DustAuthType } from '../..';
+import mimeTypes from 'mime-types';
+import { FileUploadUrlRequestType } from '@dust-tt/client';
+
+export const uploadFile = createAction({
+  name: 'uploadFile',
+  displayName: 'Upload file',
+  description: 'Upload file to be used in conversation',
+  auth: dustAuth,
+  props: {
+    file: Property.File({
+      displayName: 'File',
+      required: true,
+    }),
+  },
+  async run({ auth, propsValue: { file } }) {
+    const client = createClient(auth as DustAuthType);
+
+    const contentType = (mimeTypes.lookup(file.filename) ||
+      'text/plain') as FileUploadUrlRequestType['contentType'];
+
+    const fileObject = new File([file.data], file.filename, {
+      type: contentType,
+    });
+
+    const response = await client.uploadFile({
+      contentType,
+      fileObject,
+      fileName: file.filename,
+      fileSize: fileObject.size,
+      useCase: 'conversation',
+    });
+
+    if (response.isErr()) {
+      throw new Error(`API Error: ${response.error.message}`);
+    }
+
+    return response.value;
+  },
+});

--- a/packages/pieces/community/dust/src/lib/common.ts
+++ b/packages/pieces/community/dust/src/lib/common.ts
@@ -3,11 +3,22 @@ import {
   httpClient,
   HttpMessageBody,
   HttpMethod,
-  HttpRequest,
 } from '@activepieces/pieces-common';
 import { DustAuthType } from '..';
+import { DustAPI } from '@dust-tt/client';
 
 export const DUST_BASE_URL = 'https://dust.tt/api/v1/w';
+
+export const createClient = (auth: DustAuthType) => {
+  return new DustAPI(
+    { url: 'https://dust.tt' },
+    {
+      workspaceId: auth.workspaceId,
+      apiKey: auth.apiKey,
+    },
+    console
+  );
+};
 
 export const assistantProp = Property.Dropdown({
   displayName: 'Agent',
@@ -21,30 +32,22 @@ export const assistantProp = Property.Dropdown({
         placeholder: 'Please authenticate first',
       };
     }
-    const { workspaceId, apiKey } = auth as DustAuthType;
-    const request: HttpRequest = {
-      method: HttpMethod.GET,
-      url: `${DUST_BASE_URL}/${workspaceId}/assistant/agent_configurations`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-    };
-    const response = await httpClient.sendRequest(request);
-    const options = response.body['agentConfigurations']
-      ?.filter(
-        (agentConfiguration: { status: string }) =>
-          agentConfiguration.status === 'active'
-      )
-      ?.map(
-        (agentConfiguration: { name: string; sId: string; scope: string }) => {
-          return {
-            label: `[${agentConfiguration['scope']}] ${agentConfiguration['name']}`,
-            value: agentConfiguration['sId'],
-          };
-        }
-      )
-      ?.sort((a: { label: string }, b: { label: string }) =>
+    const client = createClient(auth as DustAuthType);
+    const response = await client.getAgentConfigurations({});
+
+    if (response.isErr()) {
+      throw new Error(`API Error: ${response.error.message}`);
+    }
+
+    const options = response.value
+      .filter((agentConfiguration) => agentConfiguration.status === 'active')
+      .map((agentConfiguration) => {
+        return {
+          label: `[${agentConfiguration['scope']}] ${agentConfiguration['name']}`,
+          value: agentConfiguration['sId'],
+        };
+      })
+      .sort((a: { label: string }, b: { label: string }) =>
         a['label'].localeCompare(b['label'])
       );
     return {


### PR DESCRIPTION
## What does this PR do?

Add support for [Dust's file upload](https://docs.dust.tt/reference/post_api-v1-w-wid-files).

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works

A new piece allows uploading a file, and uploads it to Dust, using its official SDK. As a result, the uploaded file can be referenced in downstream pieces.

The file upload concept is replacing the fragment one on Dust's side. For now we are keeping support for both.

The "create conversation" piece is also updated so we can reference a previously uploaded file (instead of fragment's content)

Also took the opportunity to use the official Dust JS SDK (instead of direct API calls). I only migrated a couple of calls though.

<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->
