### PR TITLE
feat(google-docs): add placeholder format choice for edit

### DIFF
--- a/packages/pieces/community/google-docs/package.json
+++ b/packages/pieces/community/google-docs/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-google-docs",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/packages/pieces/community/google-docs/src/index.ts
+++ b/packages/pieces/community/google-docs/src/index.ts
@@ -34,6 +34,7 @@ export const googleDocs = createPiece({
 		'khaledmashaly',
 		'abuaboud',
 		'AbdullahBitar',
+		'Kevinyu-alan'
 	],
 	auth: googleDocsAuth,
 	actions: [


### PR DESCRIPTION
## What does this PR do?

We allow the user to choose the placeholder he wants for the google doc edit action. It will be "[[]]" by default and he can also choose "{{}}".


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes Q-1269
