### PR TITLE
feat(slack): properly handle button interaction payloads

### DIFF
--- a/packages/pieces/community/framework/src/lib/piece.ts
+++ b/packages/pieces/community/framework/src/lib/piece.ts
@@ -7,6 +7,7 @@ import {
 } from '@activepieces/shared';
 import { PieceBase, PieceMetadata} from './piece-metadata';
 import { PieceAuthProperty } from './property/authentication';
+import { ServerContext } from './context';
 
 
 export class Piece<PieceAuth extends PieceAuthProperty = PieceAuthProperty>
@@ -100,7 +101,7 @@ type CreatePieceParams<
 };
 
 type PieceEventProcessors = {
-  parseAndReply: (ctx: { payload: EventPayload }) => ParseEventResponse;
+  parseAndReply: (ctx: { payload: EventPayload, server: Omit<ServerContext, 'token' | 'apiUrl'> }) => ParseEventResponse;
   verify: (ctx: {
     webhookSecret: string | Record<string, string>;
     payload: EventPayload;

--- a/packages/pieces/community/slack/package.json
+++ b/packages/pieces/community/slack/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@activepieces/piece-slack",
-  "version": "0.9.5"
+  "version": "0.10.0"
 }

--- a/packages/pieces/community/slack/src/index.ts
+++ b/packages/pieces/community/slack/src/index.ts
@@ -1,10 +1,15 @@
-import { createCustomApiCallAction } from '@activepieces/pieces-common';
 import {
+  createCustomApiCallAction,
+  httpClient,
+  HttpMethod,
+} from '@activepieces/pieces-common';
+import {
+  createPiece,
   OAuth2PropertyValue,
   PieceAuth,
-  createPiece,
   Property,
 } from '@activepieces/pieces-framework';
+
 import { PieceCategory } from '@activepieces/shared';
 import crypto from 'node:crypto';
 import { requestActionDirectMessageAction } from './lib/actions/request-action-direct-message';
@@ -77,32 +82,68 @@ export const slackAuth = PieceAuth.OAuth2({
     'emoji:read',
     'users.profile:read',
     'channels:write.invites',
-    'groups:write.invites'
+    'groups:write.invites',
   ],
 });
 
 export const slack = createPiece({
   displayName: 'Slack',
   description: 'Channel-based messaging platform',
-  minimumSupportedRelease: '0.30.0',
+  minimumSupportedRelease: '0.66.7',
   logoUrl: 'https://cdn.activepieces.com/pieces/slack.png',
   categories: [PieceCategory.COMMUNICATION],
   auth: slackAuth,
   events: {
-    parseAndReply: ({ payload }) => {
-      const payloadBody = payload.body as PayloadBody;
-      if (payloadBody.challenge) {
+    parseAndReply: ({ payload, server }) => {
+      if (
+        payload.headers['content-type'] === 'application/x-www-form-urlencoded'
+      ) {
+        if (
+          payload.body &&
+          typeof payload.body == 'object' &&
+          'payload' in payload.body
+        ) {
+          const interactionPayloadBody = JSON.parse(
+            (payload.body as { payload: string }).payload
+          ) as InteractionPayloadBody;
+          if (interactionPayloadBody.type === 'block_actions') {
+            const action = interactionPayloadBody.actions?.at(0);
+            if (
+              action &&
+              action.type === 'button' &&
+              action.value?.startsWith(server.publicUrl)
+            ) {
+              // We don't await the promise as we don't handle the response anyway
+              httpClient.sendRequest({
+                url: action.value,
+                method: HttpMethod.POST,
+                body: interactionPayloadBody,
+              });
+            }
+          }
+        }
         return {
           reply: {
-            body: payloadBody['challenge'],
             headers: {},
+            body: {},
           },
         };
+      } else {
+        const eventPayloadBody = payload.body as EventPayloadBody;
+        if (eventPayloadBody.challenge) {
+          return {
+            reply: {
+              body: eventPayloadBody['challenge'],
+              headers: {},
+            },
+          };
+        }
+
+        return {
+          event: eventPayloadBody?.event?.type,
+          identifierValue: eventPayloadBody.team_id,
+        };
       }
-      return {
-        event: payloadBody?.event?.type,
-        identifierValue: payloadBody.team_id,
-      };
     },
     verify: ({ webhookSecret, payload }) => {
       // Construct the signature base string
@@ -196,10 +237,19 @@ export const slack = createPiece({
   ],
 });
 
-type PayloadBody = {
+type EventPayloadBody = {
+  // Event payload
   challenge: string;
   event: {
     type: string;
   };
   team_id: string;
+};
+type InteractionPayloadBody = {
+  // Interaction payload
+  type?: string;
+  actions?: {
+    type: string;
+    value: string;
+  }[];
 };

--- a/packages/pieces/community/slack/src/lib/actions/request-action-message.ts
+++ b/packages/pieces/community/slack/src/lib/actions/request-action-message.ts
@@ -8,6 +8,7 @@ import {
   username,
   actions,
   singleSelectChannelInfo,
+  threadTs,
 } from '../common/props';
 import { requestAction } from '../common/request-action';
 
@@ -22,6 +23,7 @@ export const requestActionMessageAction = createAction({
     channel: slackChannel(true),
     text,
     actions,
+    threadTs,
     username,
     profilePicture,
   },

--- a/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
+++ b/packages/pieces/community/slack/src/lib/actions/send-message-action.ts
@@ -4,6 +4,7 @@ import {
   slackChannel,
   username,
   blocks,
+  threadTs,
   singleSelectChannelInfo,
 } from '../common/props';
 import { processMessageTimestamp, slackSendMessage } from '../common/utils';
@@ -30,19 +31,14 @@ export const slackSendMessageAction = createAction({
       displayName: 'Attachment',
       required: false,
     }),
-    threadTs: Property.ShortText({
-      displayName: 'Thread ts',
-      description:
-        'Provide the ts (timestamp) value of the **parent** message to make this message a reply. Do not use the ts value of the reply itself; use its parent instead. For example `1710304378.475129`.Alternatively, you can easily obtain the message link by clicking on the three dots next to the parent message and selecting the `Copy link` option.',
-      required: false,
-    }),
+    threadTs,
     blocks,
   },
   async run(context) {
     const token = context.auth.access_token;
     const { text, channel, username, profilePicture, threadTs, file,blocks } =
       context.propsValue;
-    
+
     const blockList = blocks ?[{ type: 'section', text: { type: 'mrkdwn', text } }, ...(blocks as unknown as (KnownBlock | Block)[])] :undefined
 
     return slackSendMessage({

--- a/packages/pieces/community/slack/src/lib/common/props.ts
+++ b/packages/pieces/community/slack/src/lib/common/props.ts
@@ -121,6 +121,24 @@ export const text = Property.LongText({
 export const actions = Property.Array({
   displayName: 'Action Buttons',
   required: true,
+  properties: {
+    label: Property.ShortText({
+      displayName: 'Label',
+      required: true,
+    }),
+    style: Property.StaticDropdown({
+      displayName: 'Style',
+      required: false,
+      defaultValue: null,
+      options: {
+        options: [
+          { label: 'Default', value: null },
+          { label: 'Primary', value: 'primary' },
+          { label: 'Danger', value: 'danger' },
+        ],
+      },
+    }),
+  },
 });
 
 export async function getChannels(accessToken: string) {

--- a/packages/pieces/community/slack/src/lib/common/props.ts
+++ b/packages/pieces/community/slack/src/lib/common/props.ts
@@ -6,15 +6,17 @@ const slackChannelBotInstruction = `
 	  1. Type /invite in the channel's chat.
 	  2. Click on Add apps to this channel.
 	  3. Search for and add the bot.
-  `
+  `;
 
 export const multiSelectChannelInfo = Property.MarkDown({
-  value: slackChannelBotInstruction +
+  value:
+    slackChannelBotInstruction +
     `\n**Note**: If you can't find the channel in the dropdown list (which fetches up to 2000 channels), please click on the **(F)** and type the channel ID directly in an array like this: \`{\`{ ['your_channel_id_1', 'your_channel_id_2', ...] \`}\`}`,
 });
 
 export const singleSelectChannelInfo = Property.MarkDown({
-  value: slackChannelBotInstruction +
+  value:
+    slackChannelBotInstruction +
     `\n**Note**: If you can't find the channel in the dropdown list (which fetches up to 2000 channels), please click on the **(F)** and type the channel ID directly.
   `,
 });
@@ -56,6 +58,13 @@ export const username = Property.ShortText({
 export const profilePicture = Property.ShortText({
   displayName: 'Profile Picture',
   description: 'The profile picture of the bot',
+  required: false,
+});
+
+export const threadTs = Property.ShortText({
+  displayName: 'Thread ts',
+  description:
+    'Provide the ts (timestamp) value of the **parent** message to make this message a reply. Do not use the ts value of the reply itself; use its parent instead. For example `1710304378.475129`.Alternatively, you can easily obtain the message link by clicking on the three dots next to the parent message and selecting the `Copy link` option.',
   required: false,
 });
 

--- a/packages/pieces/community/slack/src/lib/common/request-action.ts
+++ b/packages/pieces/community/slack/src/lib/common/request-action.ts
@@ -1,4 +1,4 @@
-import { slackSendMessage } from './utils';
+import { processMessageTimestamp, slackSendMessage } from './utils';
 import {
   assertNotNullOrUndefined,
   ExecutionType,
@@ -61,6 +61,7 @@ export const requestAction = async (conversationId: string, context: any) => {
       text: `${context.propsValue.text}`,
       username,
       profilePicture,
+      threadTs: context.propsValue.threadTs ? processMessageTimestamp(context.propsValue.threadTs) : undefined,
       blocks: [
         {
           type: 'section',

--- a/packages/pieces/community/slack/src/lib/common/request-action.ts
+++ b/packages/pieces/community/slack/src/lib/common/request-action.ts
@@ -14,22 +14,27 @@ export const requestAction = async (conversationId: string, context: any) => {
     throw new Error(`Must have at least one button action`);
   }
 
-  const actionTextToIds = actions.map((actionText: string) => {
-    if (!actionText) {
-      throw new Error(`Button text for the action cannot be empty`);
-    }
+  const actionTextToIds = actions.map(
+    ({ label, style }: { label: string; style: string }) => {
+      if (!label) {
+        throw new Error(`Button text for the action cannot be empty`);
+      }
 
-    return {
-      actionText,
-      actionId: encodeURI(actionText as string),
-    };
-  });
+      return {
+        label,
+        style,
+        actionId: encodeURI(label as string),
+      };
+    }
+  );
 
   if (context.executionType === ExecutionType.BEGIN) {
     context.run.pause({
       pauseMetadata: {
         type: PauseType.WEBHOOK,
-        actions: actionTextToIds.map((action: any) => action.actionId),
+        actions: actionTextToIds.map(
+          (action: { actionId: string }) => action.actionId
+        ),
       },
     });
 
@@ -39,29 +44,33 @@ export const requestAction = async (conversationId: string, context: any) => {
     assertNotNullOrUndefined(token, 'token');
     assertNotNullOrUndefined(text, 'text');
 
-    const actionElements = actionTextToIds.map((action: any) => {
-      const actionLink = context.generateResumeUrl({
-        queryParams: { action: action.actionId },
-      });
+    const actionElements = actionTextToIds.map(
+      (action: { label: string; style: string; actionId: string }) => {
+        const actionLink = context.generateResumeUrl({
+          queryParams: { action: action.actionId },
+        });
 
-      return {
-        type: 'button',
-        text: {
-          type: 'plain_text',
-          text: action.actionText,
-        },
-        style: 'primary',
-        value: actionLink,
-        action_id: action.actionId,
-      };
-    });
+        return {
+          type: 'button',
+          text: {
+            type: 'plain_text',
+            text: action.label,
+          },
+          ...(action.style && {style: action.style}),
+          value: actionLink,
+          action_id: action.actionId,
+        };
+      }
+    );
 
     const messageResponse: ChatPostMessageResponse = await slackSendMessage({
       token,
       text: `${context.propsValue.text}`,
       username,
       profilePicture,
-      threadTs: context.propsValue.threadTs ? processMessageTimestamp(context.propsValue.threadTs) : undefined,
+      threadTs: context.propsValue.threadTs
+        ? processMessageTimestamp(context.propsValue.threadTs)
+        : undefined,
       blocks: [
         {
           type: 'section',

--- a/packages/server/api/src/app/app-event-routing/app-event-routing.module.ts
+++ b/packages/server/api/src/app/app-event-routing/app-event-routing.module.ts
@@ -27,6 +27,7 @@ import { webhookSimulationService } from '../webhooks/webhook-simulation/webhook
 import { jobQueue } from '../workers/queue'
 import { DEFAULT_PRIORITY } from '../workers/queue/queue-manager'
 import { appEventRoutingService } from './app-event-routing.service'
+import { getPublicUrl } from '../../../../worker/src/lib/utils/machine';
 
 const appWebhooks: Record<string, Piece> = {
     slack,
@@ -88,6 +89,9 @@ export const appEventRoutingController: FastifyPluginAsyncTypebox = async (
             assertNotNullOrUndefined(piece.events, 'Event is possible in this piece')
             const { reply, event, identifierValue } = piece.events.parseAndReply({
                 payload,
+                server: {
+                    publicUrl: getPublicUrl(),
+                },
             })
             if (!isNil(reply)) {
                 request.log.info(

--- a/packages/server/worker/src/lib/utils/machine.ts
+++ b/packages/server/worker/src/lib/utils/machine.ts
@@ -84,7 +84,7 @@ export const workerMachine = {
     },
 }
 
-function getPublicUrl(): string {
+export function getPublicUrl(): string {
     if (isNil(settings)) {
         const url = environmentVariables.getEnvironmentOrThrow(WorkerSystemProp.FRONTEND_URL)
         return url


### PR DESCRIPTION
## What does this PR do?
We want to receive Slack interaction payloads, e.g. when sending a message with a button we can now cleanly resume the flow (without showing the user an empty tab in their browser)

:warning: the interaction URL must be set to the same event callback URL in the Slack app settings

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
