### PR TITLE
feat(dust): switch to official SDK

### DIFF
--- a/packages/pieces/community/dust/src/lib/common.ts
+++ b/packages/pieces/community/dust/src/lib/common.ts
@@ -1,8 +1,6 @@
 import { Property } from '@activepieces/pieces-framework';
 import {
-  httpClient,
   HttpMessageBody,
-  HttpMethod,
 } from '@activepieces/pieces-common';
 import { DustAuthType } from '..';
 import { DustAPI } from '@dust-tt/client';
@@ -80,16 +78,15 @@ export async function getConversationContent(
   auth: DustAuthType
 ) {
   const getConversation = async (conversationId: string) => {
-    return httpClient.sendRequest({
-      method: HttpMethod.GET,
-      url: `${DUST_BASE_URL[auth.region || 'us']}/${
-        auth.workspaceId
-      }/assistant/conversations/${conversationId}`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${auth.apiKey}`,
-      },
-    });
+    const client = createClient(auth as DustAuthType);
+
+    const response = await client.getConversation({ conversationId: conversationId });
+
+    if (response.isErr()) {
+      throw new Error(`API Error: ${response.error.message}`);
+    }
+
+    return response.value;
   };
 
   let conversation = await getConversation(conversationId);


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->
To change from a custom API implementation to use the official dust SDK


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->
The Dust piece now uses the official SDK provided by Dust 
Existing actions (create conversation, reply to conversation, upload file) now use the SDK implementation.

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
