### PR TITLE
feat: add new action to remove passwords from pdf files

### DIFF
--- a/packages/pieces/community/pdf/package.json
+++ b/packages/pieces/community/pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pdf",
-  "version": "0.2.17",
+  "version": "0.3.0",
   "dependencies": {
     "jimp": "^0.22.12",
     "pdf-parse": "1.1.1",

--- a/packages/pieces/community/pdf/package.json
+++ b/packages/pieces/community/pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activepieces/piece-pdf",
-  "version": "0.3.0",
+  "version": "0.2.18",
   "dependencies": {
     "jimp": "^0.22.12",
     "pdf-parse": "1.1.1",

--- a/packages/pieces/community/pdf/src/index.ts
+++ b/packages/pieces/community/pdf/src/index.ts
@@ -6,6 +6,7 @@ import { imageToPdf } from './lib/actions/image-to-pdf';
 import { pdfPageCount } from './lib/actions/pdf-page-count';
 import { extractPdfPages } from './lib/actions/extract-pdf-pages';
 import { mergePdfs } from './lib/actions/merge-pdfs';
+import { removePassword } from './lib/actions/remove-password';
 
 export const PDF = createPiece({
   displayName: 'PDF',
@@ -27,6 +28,7 @@ export const PDF = createPiece({
     pdfPageCount,
     extractPdfPages,
     mergePdfs,
+    removePassword,
   ],
   triggers: [],
 });

--- a/packages/pieces/community/pdf/src/lib/actions/remove-password.ts
+++ b/packages/pieces/community/pdf/src/lib/actions/remove-password.ts
@@ -1,0 +1,67 @@
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { PDFDocument } from 'pdf-lib';
+
+export const removePassword = createAction({
+  name: 'removePassword',
+  displayName: 'Remove Password',
+  description: 'Remove password protection from a PDF file to enable content manipulation',
+  props: {
+    file: Property.File({
+      displayName: 'PDF File',
+      description: 'Password-protected PDF file',
+      required: true,
+    }),
+    password: Property.ShortText({
+      displayName: 'Password',
+      description: 'Password to unlock the PDF',
+      required: true,
+    }),
+    outputFileName: Property.ShortText({
+      displayName: 'Output File Name',
+      description: 'Name for the unprotected PDF file (without extension)',
+      required: false,
+      defaultValue: 'unlocked-document',
+    }),
+  },
+  errorHandlingOptions: {
+    continueOnFailure: {
+      defaultValue: false,
+    },
+    retryOnFailure: {
+      hide: true,
+    },
+  },
+  async run(context) {
+    const { file, password, outputFileName } = context.propsValue;
+
+    try {
+      const pdfBytes = new Uint8Array(Buffer.isBuffer(file.data) ? file.data : Buffer.from(file.data));
+
+      const pdfDoc = await PDFDocument.load(pdfBytes, {
+        password,
+        ignoreEncryption: true,
+        updateMetadata: false,
+      } as any);
+
+      const decryptedBytes = await pdfDoc.save();
+
+      return context.files.write({
+        data: Buffer.from(decryptedBytes),
+        fileName: `${outputFileName}.pdf`,
+      });
+
+    } catch (error) {
+      const errorMessage = (error as Error).message || 'Unknown error';
+      
+      if (errorMessage.includes('password')) {
+        throw new Error('Invalid password or PDF is not password-protected');
+      }
+      if (errorMessage.includes('encrypted') || errorMessage.includes('encryption')) {
+        throw new Error('Unsupported encryption type.');
+      }
+      
+      throw new Error(`Failed to remove password from PDF: ${errorMessage}`);
+    }
+  },
+});
+


### PR DESCRIPTION
## What does this PR do?

<!-- We need a clear description of what the PR does, as this will be used for the marketing team to generate the release notes. -->
Adds a new `Remove Password` action to the PDF piece that allows users to unlock password-protected PDF files and save them without encryption


### Explain How the Feature Works
<!-- Adding a video demonstration is optional but encourged! It helps reviewers / marketing team understand your implementation better. -->
<!-- [Insert the video link here] -->
It uses `pdf-lib` to load the encrypted PDF with the provided password and saves it without encryption. The resulting PDF can be used without password restrictions.

### Relevant User Scenarios

<!-- List specific use cases where this feature would be valuable. -->
<!-- [Insert Pylon tickets or community posts here if possible] -->



Fixes # (issue)
