### PR TITLE
feat(zernio): add Zernio piece

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -3887,7 +3887,7 @@
     },
     "packages/pieces/community/google-sheets": {
       "name": "@activepieces/piece-google-sheets",
-      "version": "0.16.7",
+      "version": "0.16.8",
       "dependencies": {
         "@activepieces/core-piece-types": "workspace:*",
         "@activepieces/core-utils": "workspace:*",
@@ -9983,6 +9983,16 @@
         "tslib": "^2.3.0",
       },
     },
+    "packages/pieces/community/zernio": {
+      "name": "@activepieces/piece-zernio",
+      "version": "0.0.1",
+      "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2",
+      },
+    },
     "packages/pieces/community/zerobounce": {
       "name": "@activepieces/piece-zerobounce",
       "version": "0.1.6",
@@ -12501,6 +12511,8 @@
     "@activepieces/piece-zendesk-sell": ["@activepieces/piece-zendesk-sell@workspace:packages/pieces/community/zendesk-sell"],
 
     "@activepieces/piece-zeplin": ["@activepieces/piece-zeplin@workspace:packages/pieces/community/zeplin"],
+
+    "@activepieces/piece-zernio": ["@activepieces/piece-zernio@workspace:packages/pieces/community/zernio"],
 
     "@activepieces/piece-zerobounce": ["@activepieces/piece-zerobounce@workspace:packages/pieces/community/zerobounce"],
 

--- a/packages/pieces/community/zernio/.eslintrc.json
+++ b/packages/pieces/community/zernio/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+    "extends": ["../../../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        { "files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {} },
+        { "files": ["*.ts", "*.tsx"], "rules": {} },
+        { "files": ["*.js", "*.jsx"], "rules": {} }
+    ]
+}

--- a/packages/pieces/community/zernio/.eslintrc.json
+++ b/packages/pieces/community/zernio/.eslintrc.json
@@ -1,9 +1,47 @@
 {
-    "extends": ["../../../../.eslintrc.json"],
-    "ignorePatterns": ["!**/*"],
-    "overrides": [
-        { "files": ["*.ts", "*.tsx", "*.js", "*.jsx"], "rules": {} },
-        { "files": ["*.ts", "*.tsx"], "rules": {} },
-        { "files": ["*.js", "*.jsx"], "rules": {} }
-    ]
+  "extends": [
+    "../../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "lodash",
+              "lodash/*",
+              "@activepieces/core-*",
+              "@activepieces/server*",
+              "@activepieces/engine",
+              "@activepieces/shared"
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
 }

--- a/packages/pieces/community/zernio/README.md
+++ b/packages/pieces/community/zernio/README.md
@@ -1,0 +1,5 @@
+# pieces-zernio
+
+## Building
+
+Run `turbo run build --filter=@activepieces/piece-zernio` to build the library.

--- a/packages/pieces/community/zernio/package.json
+++ b/packages/pieces/community/zernio/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "@activepieces/piece-zernio",
+    "version": "0.0.1",
+    "main": "./dist/src/index.js",
+    "types": "./dist/src/index.d.ts",
+    "scripts": {
+        "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+        "lint": "eslint 'src/**/*.ts'"
+    },
+    "dependencies": {
+        "@activepieces/pieces-common": "workspace:*",
+        "@activepieces/pieces-framework": "workspace:*",
+        "@activepieces/shared": "workspace:*",
+        "tslib": "2.6.2"
+    }
+}

--- a/packages/pieces/community/zernio/package.json
+++ b/packages/pieces/community/zernio/package.json
@@ -1,16 +1,21 @@
 {
-    "name": "@activepieces/piece-zernio",
-    "version": "0.0.1",
-    "main": "./dist/src/index.js",
-    "types": "./dist/src/index.d.ts",
-    "scripts": {
-        "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
-        "lint": "eslint 'src/**/*.ts'"
-    },
-    "dependencies": {
-        "@activepieces/pieces-common": "workspace:*",
-        "@activepieces/pieces-framework": "workspace:*",
-        "@activepieces/shared": "workspace:*",
-        "tslib": "2.6.2"
-    }
+  "name": "@activepieces/piece-zernio",
+  "version": "0.0.1",
+  "type": "commonjs",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.lib.json && cp package.json dist/",
+    "lint": "eslint 'src/**/*.ts'",
+    "bundle": "node ../../../../dist/packages/cli/src/index.js pieces bundle"
+  },
+  "dependencies": {
+    "@activepieces/pieces-common": "workspace:*",
+    "@activepieces/pieces-framework": "workspace:*",
+    "@activepieces/core-piece-types": "workspace:*",
+    "@activepieces/core-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "tslib": "2.6.2"
+  }
 }

--- a/packages/pieces/community/zernio/src/index.ts
+++ b/packages/pieces/community/zernio/src/index.ts
@@ -1,6 +1,5 @@
 import { createCustomApiCallAction } from '@activepieces/pieces-common';
-import { createPiece } from '@activepieces/pieces-framework';
-import { PieceCategory } from '@activepieces/shared';
+import { createPiece, PieceCategory } from '@activepieces/pieces-framework';
 import { createPost } from './lib/actions/create-post';
 import { sendSms } from './lib/actions/send-sms';
 import { zernioAuth } from './lib/auth';
@@ -14,7 +13,7 @@ export const zernio = createPiece({
     logoUrl: 'https://cdn.activepieces.com/pieces/zernio.png',
     categories: [PieceCategory.MARKETING, PieceCategory.COMMUNICATION],
     auth: zernioAuth,
-    authors: ['olivier-sambourg'],
+    authors: ['AdamSelene'],
     actions: [
         createPost,
         sendSms,

--- a/packages/pieces/community/zernio/src/index.ts
+++ b/packages/pieces/community/zernio/src/index.ts
@@ -1,0 +1,30 @@
+import { createCustomApiCallAction } from '@activepieces/pieces-common';
+import { createPiece } from '@activepieces/pieces-framework';
+import { PieceCategory } from '@activepieces/shared';
+import { createPost } from './lib/actions/create-post';
+import { sendSms } from './lib/actions/send-sms';
+import { zernioAuth } from './lib/auth';
+import { zernioCommon } from './lib/common';
+
+export const zernio = createPiece({
+    displayName: 'Zernio',
+    description:
+        'One API for social publishing and customer communication: schedule posts across platforms, run a unified inbox, and send SMS.',
+    minimumSupportedRelease: '0.36.1',
+    logoUrl: 'https://cdn.activepieces.com/pieces/zernio.png',
+    categories: [PieceCategory.MARKETING, PieceCategory.COMMUNICATION],
+    auth: zernioAuth,
+    authors: ['olivier-sambourg'],
+    actions: [
+        createPost,
+        sendSms,
+        createCustomApiCallAction({
+            baseUrl: () => zernioCommon.BASE_URL,
+            auth: zernioAuth,
+            authMapping: async (auth) => ({
+                Authorization: `Bearer ${auth.secret_text}`,
+            }),
+        }),
+    ],
+    triggers: [],
+});

--- a/packages/pieces/community/zernio/src/lib/actions/create-post.ts
+++ b/packages/pieces/community/zernio/src/lib/actions/create-post.ts
@@ -34,19 +34,19 @@ export const createPost = createAction({
         scheduledFor: Property.DateTime({
             displayName: 'Scheduled For',
             description:
-                'When to publish, in ISO 8601 format (e.g. 2026-04-17T10:30:00Z). Ignored when Publish Now is enabled.',
-            required: false,
-        }),
-        timezone: Property.ShortText({
-            displayName: 'Timezone',
-            description:
-                'IANA timezone for the scheduled time (e.g. America/New_York). Defaults to UTC.',
+                'When to publish, as a UTC time (e.g. 2026-04-17T10:30:00Z). Ignored when Publish Now is enabled.',
             required: false,
         }),
     },
     async run(context) {
-        const { content, accounts, publishNow, scheduledFor, timezone } =
+        const { content, accounts, publishNow, scheduledFor } =
             context.propsValue;
+
+        if (!publishNow && !scheduledFor) {
+            throw new Error(
+                'Enable Publish Now or set a Scheduled For time — otherwise the post is only saved as a draft.'
+            );
+        }
 
         const response = await httpClient.sendRequest({
             method: HttpMethod.POST,
@@ -58,10 +58,9 @@ export const createPost = createAction({
             body: {
                 content,
                 platforms: accounts,
-                ...(publishNow ? { publishNow: true } : {}),
-                ...(!publishNow && scheduledFor
-                    ? { scheduledFor, timezone: timezone ?? 'UTC' }
-                    : {}),
+                ...(publishNow
+                    ? { publishNow: true }
+                    : { scheduledFor, timezone: 'UTC' }),
             },
         });
         return response.body;

--- a/packages/pieces/community/zernio/src/lib/actions/create-post.ts
+++ b/packages/pieces/community/zernio/src/lib/actions/create-post.ts
@@ -1,0 +1,69 @@
+import {
+    AuthenticationType,
+    HttpMethod,
+    httpClient,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zernioAuth } from '../auth';
+import { zernioCommon } from '../common';
+
+export const createPost = createAction({
+    auth: zernioAuth,
+    name: 'create_post',
+    displayName: 'Create Post',
+    description: 'Schedule or immediately publish a post to one or more connected social accounts.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Publish or schedule a social media post across one or more connected accounts in Zernio. Provide the text content and pick the target accounts. Set Publish Now to post immediately, or provide a Scheduled For time to queue it. Each call creates a new post, so retries duplicate.',
+        idempotent: false,
+    },
+    props: {
+        content: Property.LongText({
+            displayName: 'Content',
+            description: 'The text of the post.',
+            required: true,
+        }),
+        accounts: zernioCommon.accountsProperty,
+        publishNow: Property.Checkbox({
+            displayName: 'Publish Now',
+            description: 'Publish immediately instead of scheduling for a later time.',
+            required: false,
+            defaultValue: false,
+        }),
+        scheduledFor: Property.DateTime({
+            displayName: 'Scheduled For',
+            description:
+                'When to publish, in ISO 8601 format (e.g. 2026-04-17T10:30:00Z). Ignored when Publish Now is enabled.',
+            required: false,
+        }),
+        timezone: Property.ShortText({
+            displayName: 'Timezone',
+            description:
+                'IANA timezone for the scheduled time (e.g. America/New_York). Defaults to UTC.',
+            required: false,
+        }),
+    },
+    async run(context) {
+        const { content, accounts, publishNow, scheduledFor, timezone } =
+            context.propsValue;
+
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `${zernioCommon.BASE_URL}/posts`,
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: context.auth.secret_text,
+            },
+            body: {
+                content,
+                platforms: accounts,
+                ...(publishNow ? { publishNow: true } : {}),
+                ...(!publishNow && scheduledFor
+                    ? { scheduledFor, timezone: timezone ?? 'UTC' }
+                    : {}),
+            },
+        });
+        return response.body;
+    },
+});

--- a/packages/pieces/community/zernio/src/lib/actions/send-sms.ts
+++ b/packages/pieces/community/zernio/src/lib/actions/send-sms.ts
@@ -1,0 +1,53 @@
+import {
+    AuthenticationType,
+    HttpMethod,
+    httpClient,
+} from '@activepieces/pieces-common';
+import { createAction, Property } from '@activepieces/pieces-framework';
+import { zernioAuth } from '../auth';
+import { zernioCommon } from '../common';
+
+export const sendSms = createAction({
+    auth: zernioAuth,
+    name: 'send_sms',
+    displayName: 'Send SMS',
+    description: 'Send an SMS text message from one of your Zernio phone numbers.',
+    audience: 'both',
+    aiMetadata: {
+        description:
+            'Send an SMS message via Zernio. Provide the sender number (one of your SMS-enabled Zernio numbers), the recipient number, and the message text. Each call sends a new message, so retries send duplicates.',
+        idempotent: false,
+    },
+    props: {
+        from: Property.ShortText({
+            displayName: 'From',
+            description:
+                'One of your SMS-enabled Zernio numbers, in E.164 format (e.g. +14155550123).',
+            required: true,
+        }),
+        to: Property.ShortText({
+            displayName: 'To',
+            description: 'Recipient phone number in E.164 format (e.g. +14155550199).',
+            required: true,
+        }),
+        text: Property.LongText({
+            displayName: 'Message',
+            description: 'The text content of the SMS.',
+            required: true,
+        }),
+    },
+    async run(context) {
+        const { from, to, text } = context.propsValue;
+
+        const response = await httpClient.sendRequest({
+            method: HttpMethod.POST,
+            url: `${zernioCommon.BASE_URL}/sms/messages`,
+            authentication: {
+                type: AuthenticationType.BEARER_TOKEN,
+                token: context.auth.secret_text,
+            },
+            body: { from, to, text },
+        });
+        return response.body;
+    },
+});

--- a/packages/pieces/community/zernio/src/lib/auth.ts
+++ b/packages/pieces/community/zernio/src/lib/auth.ts
@@ -1,0 +1,8 @@
+import { PieceAuth } from '@activepieces/pieces-framework';
+
+export const zernioAuth = PieceAuth.SecretText({
+    displayName: 'API Key',
+    description:
+        'Log in to zernio.com, open Settings > API Keys, and create a key. It starts with `sk_`.',
+    required: true,
+});

--- a/packages/pieces/community/zernio/src/lib/common/index.ts
+++ b/packages/pieces/community/zernio/src/lib/common/index.ts
@@ -9,15 +9,12 @@ import { zernioAuth } from '../auth';
 const BASE_URL = 'https://zernio.com/api/v1';
 
 async function listAccounts(apiKey: string): Promise<ZernioAccount[]> {
-    const response = await httpClient.sendRequest<
-        { accounts?: ZernioAccount[] } | ZernioAccount[]
-    >({
+    const response = await httpClient.sendRequest<{ accounts?: ZernioAccount[] }>({
         method: HttpMethod.GET,
         url: `${BASE_URL}/accounts`,
         authentication: { type: AuthenticationType.BEARER_TOKEN, token: apiKey },
     });
-    const body = response.body;
-    return Array.isArray(body) ? body : body.accounts ?? [];
+    return response.body.accounts ?? [];
 }
 
 const accountsProperty = Property.MultiSelectDropdown({
@@ -39,7 +36,7 @@ const accountsProperty = Property.MultiSelectDropdown({
             disabled: false,
             options: accounts.map((account) => ({
                 label: `${account.platform}: ${
-                    account.name ?? account.username ?? account._id
+                    account.displayName ?? account.username ?? account._id
                 }`,
                 value: { platform: account.platform, accountId: account._id },
             })),
@@ -52,6 +49,6 @@ export const zernioCommon = { BASE_URL, accountsProperty };
 type ZernioAccount = {
     _id: string;
     platform: string;
-    name?: string;
     username?: string;
+    displayName?: string;
 };

--- a/packages/pieces/community/zernio/src/lib/common/index.ts
+++ b/packages/pieces/community/zernio/src/lib/common/index.ts
@@ -1,0 +1,57 @@
+import {
+    AuthenticationType,
+    HttpMethod,
+    httpClient,
+} from '@activepieces/pieces-common';
+import { Property } from '@activepieces/pieces-framework';
+import { zernioAuth } from '../auth';
+
+const BASE_URL = 'https://zernio.com/api/v1';
+
+async function listAccounts(apiKey: string): Promise<ZernioAccount[]> {
+    const response = await httpClient.sendRequest<
+        { accounts?: ZernioAccount[] } | ZernioAccount[]
+    >({
+        method: HttpMethod.GET,
+        url: `${BASE_URL}/accounts`,
+        authentication: { type: AuthenticationType.BEARER_TOKEN, token: apiKey },
+    });
+    const body = response.body;
+    return Array.isArray(body) ? body : body.accounts ?? [];
+}
+
+const accountsProperty = Property.MultiSelectDropdown({
+    displayName: 'Accounts',
+    description: 'The connected social accounts to publish to.',
+    required: true,
+    auth: zernioAuth,
+    refreshers: [],
+    options: async ({ auth }) => {
+        if (!auth) {
+            return {
+                disabled: true,
+                options: [],
+                placeholder: 'Connect your Zernio account first',
+            };
+        }
+        const accounts = await listAccounts(auth.secret_text);
+        return {
+            disabled: false,
+            options: accounts.map((account) => ({
+                label: `${account.platform}: ${
+                    account.name ?? account.username ?? account._id
+                }`,
+                value: { platform: account.platform, accountId: account._id },
+            })),
+        };
+    },
+});
+
+export const zernioCommon = { BASE_URL, accountsProperty };
+
+type ZernioAccount = {
+    _id: string;
+    platform: string;
+    name?: string;
+    username?: string;
+};

--- a/packages/pieces/community/zernio/tsconfig.json
+++ b/packages/pieces/community/zernio/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "extends": "../../../../tsconfig.base.json",
+    "compilerOptions": {
+        "module": "commonjs",
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "files": [],
+    "include": [],
+    "references": [{ "path": "./tsconfig.lib.json" }]
+}

--- a/packages/pieces/community/zernio/tsconfig.lib.json
+++ b/packages/pieces/community/zernio/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "baseUrl": ".",
+        "paths": {},
+        "outDir": "./dist",
+        "declaration": true,
+        "types": ["node"]
+    },
+    "include": ["src/**/*.ts"],
+    "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/pieces/community/zernio/tsconfig.lib.json
+++ b/packages/pieces/community/zernio/tsconfig.lib.json
@@ -6,6 +6,7 @@
         "paths": {},
         "outDir": "./dist",
         "declaration": true,
+        "declarationMap": true,
         "types": ["node"]
     },
     "include": ["src/**/*.ts"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1529,6 +1529,9 @@
       "@activepieces/piece-zendesk": [
         "packages/pieces/community/zendesk/src/index.ts"
       ],
+      "@activepieces/piece-zernio": [
+        "packages/pieces/community/zernio/src/index.ts"
+      ],
       "@activepieces/piece-zerobounce": [
         "packages/pieces/community/zerobounce/src/index.ts"
       ],


### PR DESCRIPTION
## Description

Adds a new **Zernio** piece — Zernio is one API for social publishing and customer communication.

Included:
- **Auth** — API key (Bearer token), created in Zernio Settings > API Keys
- **Custom API Call** — against `https://zernio.com/api/v1`
- **Create Post** — publish or schedule a post to one or more connected accounts, using a dynamic multi-select account dropdown (users pick accounts by name, not IDs)
- **Send SMS** — send an SMS from a Zernio-provisioned number

More than a bare custom-API-call piece, per the pieces contribution guideline.

## How was this tested?

- `npx turbo run build --filter=@activepieces/piece-zernio` — passes
- `npx turbo run lint --filter=@activepieces/piece-zernio` — passes

Not yet exercised against live Zernio credentials; request/response shapes follow docs.zernio.com. `/accounts` parsing tolerates both a bare array and an `{ accounts: [...] }` wrapper since the docs don't pin it down.

Fixes # (issue)

### Breaking change?  (required — CI fails if this is left unedited)

- [x] no — reviewed, not breaking
- [ ] yes — technical (removed/renamed API field or endpoint, dropped column, new required field, removed/required env var)
- [ ] yes — functional (default/limit/behaviour change, new self-hosted setup step)

### Security impact?  (required — CI fails if this is left unedited)

- [x] no — reviewed, no security impact
- [ ] yes — security-sensitive (call out the risk and mitigation in the description above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)